### PR TITLE
Add "const" modifier to pipe parameters

### DIFF
--- a/pipe.ts
+++ b/pipe.ts
@@ -166,7 +166,7 @@ type PipedFnTo<T> = {
      * @param args additional arguments to be passed to the function, if any
      * @returns the pipe for further chaining
      */
-    <U, A extends readonly any[]>(fn: (x: T, ...args: A) => U, ...args: A): Pipe<T, U, "to">;
+    <U, const A extends readonly any[]>(fn: (x: T, ...args: A) => U, ...args: A): Pipe<T, U, "to">;
     <U>(fn: (x: T) => U): Pipe<T, U, "to">;
     <U>(fn: () => U): Pipe<T, U, "to">;
 };
@@ -179,7 +179,7 @@ type PipedFnTap<T> = {
      * @param args additional arguments to be passed to the function, if any
      * @returns the pipe for further chaining
      */
-    <U, A extends readonly any[]>(fn: (x: T, ...args: A) => U, ...args: A): Pipe<T, U, "tap">;
+    <U, const A extends readonly any[]>(fn: (x: T, ...args: A) => U, ...args: A): Pipe<T, U, "tap">;
     <U>(fn: (x: T) => U): Pipe<T, U, "tap">;
     <U>(fn: () => U): Pipe<T, U, "tap">;
 };


### PR DESCRIPTION
Using `const` for these arguments is better for many use-cases, here's one example:

Without const:
![image](https://github.com/trvswgnr/sloth-pipe/assets/5869818/1c595d69-1252-44ad-83f1-dc71063acd45)

With const:
![image](https://github.com/trvswgnr/sloth-pipe/assets/5869818/c81e0ad6-374b-4e0d-a79e-a0bf3f1a314b)
